### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,82 @@
+# -----------------------------------------------------------------------------------
 # Godot 4+ specific ignores
-.godot/
+# -----------------------------------------------------------------------------------
+.godot/                     # Godot 4.0+ metadata folder
 
 # Godot-specific ignores
-.import/
-export.cfg
-export_presets.cfg
+.import/                    # Import cache folder
+export.cfg                  # Export configuration
+export_presets.cfg          # Export presets configuration
+
+# -----------------------------------------------------------------------------------
+# Common auto-generated or temporary files
+# -----------------------------------------------------------------------------------
+*.tmp                       # Temp files
+*.swap                      # Swap files (e.g., from some editors)
+*.log                       # Log files
+*.log.*                     # Rotated logs
+
+# -----------------------------------------------------------------------------------
+# Editor/IDE config & system files
+# -----------------------------------------------------------------------------------
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux
+directory\.cache/
+
+# JetBrains (e.g., Rider, IntelliJ)
+.idea/
+*.iml
+
+# Visual Studio Code
+.vscode/
+
+# Mono / C# (if you use Godot C# projects)
+mono_crash.*
+/.mono/
+*.csproj
+*.sln
+*.user
+*.csproj.user
+*.dll
+*.pdb
+
+# -----------------------------------------------------------------------------------
+# Backup or old revisions (if you enable Godot's built-in backups)
+# -----------------------------------------------------------------------------------
+*.godot_backup
+*.old
+
+# -----------------------------------------------------------------------------------
+# Other recommended ignores
+# -----------------------------------------------------------------------------------
+# Crash dumps (if any)
+*.stackdump
+*.dmp
+
+# Backup suffixes used by some editors or OS
+*~
+*.bak
+*.orig
+
+# Node modules (in case you have a JS/TS tool in the project)
+node_modules/
+
+# Yarn / PNPM lock files
+yarn.lock
+pnpm-lock.yaml
+
+# Add any other specialized tool/language directories below
+# e.g., Python caches, Rust target directories, etc.
+
+# -----------------------------------------------------------------------------------
+# End of .gitignore
+# -----------------------------------------------------------------------------------


### PR DESCRIPTION
Explanation of Changes
Godot-specific Lines:

.godot/: A Godot 4 folder containing engine configuration or internal metadata that doesn’t need to be version-controlled. .import/: Stores imported resources, which are auto-generated. export.cfg & export_presets.cfg: Contain environment-/user-specific export configs. Common OS/Editor Junk Files:

macOS: .DS_Store, .AppleDouble, etc.
Windows: Thumbs.db, Desktop.ini.
Linux: potential .cache/ directories.
IDE-specific:

JetBrains (.idea/, *.iml).
VS Code (.vscode/).
Mono/C#: If using Godot C# projects, ignore compiled artifacts (*.dll, *.pdb, etc.) and crash logs (mono_crash.*). Backups & Temporary Files:

Godot’s backup file extension, text editor backups (*.bak, *.orig, *~), logs, swap files, etc. to avoid clutter. Other Potential Artifacts:

Crash dumps (*.stackdump, *.dmp).
Node modules folder (node_modules/) if you’re using web-based tooling for asset pipelines. Yarn/PNPM lock files if relevant.
Feel free to remove lines you don’t need or add others if your project uses additional languages/frameworks (e.g., Python’s __pycache__/ or Rust’s target/). This .gitignore ensures only relevant Godot project data and source files end up in your repo, reducing bloat and risk of committing system-specific or auto-generated files.